### PR TITLE
Using object-keys instead of a homegrown keys shim.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,15 +18,7 @@
             return ret;
         }
 
-        function keys(obj) {
-            var ret = [];
-            for (var i in obj) {
-                if (hasOwn.call(obj, i)) {
-                    ret.push(i);
-                }
-            }
-            return ret;
-        }
+		var keys = require('object-keys');
 
         //taken from node js assert.js
         //https://github.com/joyent/node/blob/master/lib/assert.js

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "author": "Doug Martin",
     "license": "MIT",
     "dependencies": {
-        "extended": "~0.0.3"
+        "extended": "~0.0.3",
+        "object-keys": "~0.4.0"
     },
     "devDependencies": {
         "it": "~0.2.0",
@@ -40,3 +41,4 @@
         "grunt-contrib-jshint": "~0.3.0"
     }
 }
+


### PR DESCRIPTION
Using a more robust Object.keys shim via a module.
